### PR TITLE
Support model with unspecific input dimensions.

### DIFF
--- a/cnn_convertor/cnn_layer.py
+++ b/cnn_convertor/cnn_layer.py
@@ -479,11 +479,17 @@ class Network(object):
             for node in self.input_nodes:
                 new_dim = (dim[0], dim[1], node.input_dim[2])
                 node.set_input_dim(new_dim)
-                node.set_output_dim(new_dim)
 
         tr_list = self.traverse_list[:]
         for node in tr_list:
             if node.type == NodeType.Input:
+                # Detect if the input dimension is not undefined
+                if (node.input_dim[0] is None or node.input_dim[1] is None):
+                    msg = ("Network with undefined input dimension"
+                           "is not supported.")
+                    logging.exception(msg)
+                    raise cnn_exception.ConvertError(msg)
+                node.set_output_dim(node.input_dim)
                 continue
             # For Keras, DepthwiseConvolution node don't have output_size set.
             # Set it here

--- a/cnn_convertor/parser_caffe.py
+++ b/cnn_convertor/parser_caffe.py
@@ -97,7 +97,6 @@ def parse_caffe_def2(network: cnn_layer.Network, netdef: str):
                    caffe_net.input_shape[0].dim[2],
                    caffe_net.input_shape[0].dim[1])
         node.set_input_dim(dim)
-        node.set_output_dim(dim)
         network.debug_node = caffe_net
         top_map[caffe_net.input[0]] = node
     # Handle each layer node
@@ -159,7 +158,6 @@ def parse_caffe_def2(network: cnn_layer.Network, netdef: str):
                    layer.input_param.shape[0].dim[2],
                    layer.input_param.shape[0].dim[1])
             node.set_input_dim(dim)
-            node.set_output_dim(dim)
             network.debug_node = caffe_net
         elif node_type == NodeType.Convolution:
             param = cnn_layer.NodeParam()

--- a/cnn_convertor/parser_keras.py
+++ b/cnn_convertor/parser_keras.py
@@ -166,7 +166,6 @@ def parse_keras_network2(network, net_def, netweight, need_flip=False):
                 else:
                     dim = (shape[2], shape[1], shape[3])
             node.set_input_dim(dim)
-            node.set_output_dim(dim)
         if is_sequential:
             input_nodes = prev_node
             up_node = prev_node
@@ -442,7 +441,6 @@ def parse_keras_network2(network, net_def, netweight, need_flip=False):
                 else:
                     dim = (shape[2], shape[1], shape[3])
             node.set_input_dim(dim)
-            node.set_output_dim(dim)
         elif node_type == NodeType.Convolution:
             is_1D = (layer_type[-2] == '1')
             param = cnn_layer.NodeParam()


### PR DESCRIPTION
If width_override and height_override is specified in input config,
model with unspecific input dimensions can be supported now.

Also added log message to indicate if the input model has unspecific
input dimensions and does not use width_override and height_override.

Fix #26.