### PR TITLE
Add option to transpose weight instead of transpose input/output

### DIFF
--- a/convertor.py
+++ b/convertor.py
@@ -60,6 +60,7 @@ config.read_dict({'INPUT': {'custom_layer': '',
                              'generate_doxy': 0,
                              'generate_dot': 0,
                              'quantization': 1,
+                             'transpose_weight': 0,
                              'python_module': ''},
                   'OPTIONAL': {'verbose': 0,
                                'graphviz_path': ''}
@@ -84,6 +85,7 @@ try:
     output_gendoc = config.getboolean('OUTPUT', 'generate_doxy')
     output_gengraph = config.getboolean('OUTPUT', 'generate_dot')
     output_quantization = config.getboolean('OUTPUT', 'quantization')
+    output_transweight = config.getboolean('OUTPUT', 'transpose_weight')
     output_python_module = config['OUTPUT']['python_module']
     verbose = config.getboolean('OPTIONAL', 'verbose')
     graphviz_path = config['OPTIONAL']['graphviz_path']
@@ -128,7 +130,8 @@ if not os.path.exists(output_folder):
 # Parse network
 network = cnn_parser.parse_network(network_def, network_data, network_type,
                                    custom_layer, dim_override)
-fpga_net = fpga_layer.FPGANetwork(network, output_quantization)
+fpga_net = fpga_layer.FPGANetwork(network, output_quantization,
+                                  output_transweight)
 fpga_net.output_network(output_folder, network_name, output_gensource,
                         output_gendoc, output_gengraph, graphviz_path)
 


### PR DESCRIPTION
Currently the input/output needs to be transposed.
This commit added the option to transpose weight matrix instead so can use original input/output directly.

It's been tested on SegNetBasic demo application.
But their is some performance drop, so I set the default to not use it.