### PR TITLE
Fix KERAS data_format parsing bug for some models

### DIFF
--- a/cnn_convertor/parser_keras.py
+++ b/cnn_convertor/parser_keras.py
@@ -128,7 +128,7 @@ def parse_keras_network2(net_def, netweight, custom_layer, need_flip=False):
     is_channel_first = True
     for layer in layers:
         layer_type = layer['class_name']
-        if type_map[layer_type] is NodeType.Convolution:
+        if type_map[layer_type] in (NodeType.Convolution, NodeType.Pooling):
             if 'data_format' in layer['config']:
                 if layer['config']['data_format'] == 'channels_first':
                     is_channel_first = True

--- a/cnn_convertor/parser_keras.py
+++ b/cnn_convertor/parser_keras.py
@@ -127,9 +127,13 @@ def parse_keras_network2(net_def, netweight, custom_layer, need_flip=False):
     # get data_format parameter
     is_channel_first = True
     for layer in layers:
-        if 'data_format' in layer['config']:
-            if layer['config']['data_format'] == 'channels_first':
-                is_channel_first = True
+        layer_type = layer['class_name']
+        if type_map[layer_type] is NodeType.Convolution:
+            if 'data_format' in layer['config']:
+                if layer['config']['data_format'] == 'channels_first':
+                    is_channel_first = True
+                else:
+                    is_channel_first = False
             else:
                 is_channel_first = False
             break


### PR DESCRIPTION
Some model have convolution layers, but did not have 'data_format' config saved. In this case, the default 'data_format' should be 'channels_last' according to the document. This commit fix the problem.