### PR TITLE
Fix BatchNorm epsilon

### DIFF
--- a/cnn_convertor/cnn_layer.py
+++ b/cnn_convertor/cnn_layer.py
@@ -91,6 +91,7 @@ class NodeParam(object):
         self.axis = -1
         self.custom_param = None
         self.scale = 1.0
+        self.epsilon = 0.00001
         self.split_pool_divisor = None
         self._dilation = [1, 1]
         self.is_deconv = False
@@ -466,6 +467,7 @@ class Network(object):
                              if create_dummy else _in)
 
                 bn_node = LayerNode(node.name, NodeType.BatchNorm)
+                bn_node.param = node.param
                 bn_node.set_mean_var(node.mean, node.var)
                 base_node.bn_node = bn_node
                 if node.weight is not None or node.bias is not None:

--- a/cnn_convertor/fpga_layer.py
+++ b/cnn_convertor/fpga_layer.py
@@ -143,6 +143,10 @@ def calc_pool_tiles(node):
 def merge_bn_scale(node, kernel_size, n_c, n_m):
     weight = node.weight
     bias = node.bias
+    if node.bn_node is not None:
+        e = node.bn_node.param.epsilon
+    else:
+        e = 0.00001
     if node.bn_node is not None and node.bn_node.mean is not None:
         bn_mean = node.bn_node.mean
     else:
@@ -150,7 +154,7 @@ def merge_bn_scale(node, kernel_size, n_c, n_m):
     if node.bn_node is not None and node.bn_node.var is not None:
         bn_var = node.bn_node.var
     else:
-        bn_var = np.full_like(bias, 1.0 - 0.00001)
+        bn_var = np.full_like(bias, 1.0 - e)
     if node.sc_node is not None and node.sc_node.weight is not None:
         sc_weight = node.sc_node.weight
     else:
@@ -159,7 +163,6 @@ def merge_bn_scale(node, kernel_size, n_c, n_m):
         sc_bias = node.sc_node.bias
     else:
         sc_bias = np.zeros_like(bias)
-    e = 0.00001
     weight = np.reshape(weight, (n_m, n_c * kernel_size[1] * kernel_size[0]))
     for i in range(n_m):
         assert np.min(bn_var[i]) >= 0, "Invalid bn_var[%d]=%s" % (i, bn_var[i])

--- a/cnn_convertor/parser_caffe.py
+++ b/cnn_convertor/parser_caffe.py
@@ -127,6 +127,10 @@ def parse_caffe_def2(netdef: str):
                     param = cnn_layer.NodeParam()
                     param.relu_param = layer.relu_param.negative_slope
                     node.param = param
+                elif node_type == NodeType.BatchNorm:
+                    param = cnn_layer.NodeParam()
+                    param.epsilon = layer.batch_norm_param.eps
+                    node.param = param
                 top_map[layer.top[0]] = node
                 continue
 

--- a/cnn_convertor/parser_keras.py
+++ b/cnn_convertor/parser_keras.py
@@ -257,6 +257,9 @@ def parse_keras_network2(net_def, netweight, custom_layer, need_flip=False):
         elif layer_type == 'BatchNormalization':
             node = cnn_layer.LayerNode(layer_name, NodeType.BatchNorm,
                                        input_nodes)
+            param = cnn_layer.NodeParam()
+            param.epsilon = config['epsilon']
+            node.param = param
             if netweight is not None:
                 weights = get_weights(netweight, layer_name, need_flip,
                                       ['gamma', 'beta',


### PR DESCRIPTION
Fix BatchNorm epsilon parameter by read model setting instead of using Caffe default value.