### PR TITLE
Fix BatchNorm merge issue

### DIFF
--- a/cnn_convertor/cnn_layer.py
+++ b/cnn_convertor/cnn_layer.py
@@ -462,7 +462,8 @@ class Network(object):
                 create_dummy = (not
                                 (_in.type is NodeType.Convolution
                                  and len(_in.output_nodes) == 1
-                                 and _in.bn_node is None))
+                                 and _in.bn_node is None
+                                 and _in.act_node is None))
                 base_node = (_create_dummy_conv_node(node)
                              if create_dummy else _in)
 
@@ -483,7 +484,8 @@ class Network(object):
                 create_dummy = (not
                                 (_in.type is NodeType.Convolution
                                  and len(_in.output_nodes) == 1
-                                 and _in.sc_node is None))
+                                 and _in.sc_node is None
+                                 and _in.act_node is None))
                 base_node = (_create_dummy_conv_node(node)
                              if create_dummy else _in)
 

--- a/cnn_convertor/cnn_layer.py
+++ b/cnn_convertor/cnn_layer.py
@@ -463,6 +463,7 @@ class Network(object):
                                 (_in.type is NodeType.Convolution
                                  and len(_in.output_nodes) == 1
                                  and _in.bn_node is None
+                                 and _in.sc_node is None
                                  and _in.act_node is None))
                 base_node = (_create_dummy_conv_node(node)
                              if create_dummy else _in)

--- a/cnn_convertor/parser_keras.py
+++ b/cnn_convertor/parser_keras.py
@@ -27,7 +27,6 @@ NodeType = cnn_layer.NodeType
 
 def set_inplace_node(node, config):
     activation = config['activation']
-    input_node = None
     if activation == 'relu':
         node_type = NodeType.ReLU
     elif activation == 'tanh':
@@ -38,14 +37,9 @@ def set_inplace_node(node, config):
         node_type = NodeType.ELU
     elif activation == 'softmax':
         node_type = NodeType.SoftMax
-        input_node = node
     in_node = cnn_layer.LayerNode(node.name + '_' + activation,
-                                  node_type, input_node)
-    if input_node is None:
-        node.act_node = in_node
-        return None
-    else:
-        return in_node
+                                  node_type, node)
+    return in_node
 
 
 def get_weights(netweight, layer_name, need_flip, weight_entry):
@@ -470,7 +464,7 @@ def parse_keras_network2(net_def, netweight, custom_layer, need_flip=False):
             if config['activation'] != 'linear':
                 inplace_node = set_inplace_node(list(node_map.values())[-1], config)
                 if inplace_node:
-                    node_map[inplace_node.name] = inplace_node
+                    node_map[layer_name] = inplace_node
             if netweight is not None:
                 if layer_type[:-2] == 'SeparableConv':
                     weights = get_weights(netweight, layer_name, need_flip,
@@ -516,7 +510,7 @@ def parse_keras_network2(net_def, netweight, custom_layer, need_flip=False):
             if config['activation'] != 'linear':
                 inplace_node = set_inplace_node(node, config)
                 if inplace_node:
-                    node_map[inplace_node.name] = inplace_node
+                    node_map[layer_name] = inplace_node
             if netweight is not None:
                 weights = get_weights(netweight, layer_name, need_flip,
                                       ['kernel', 'bias'])


### PR DESCRIPTION
Currently the when the tool merge BatchNorm layer to Conv layer it does not check is it can be merged.
For example, if the flow is Conv -> Activation -> BatchNorm then it should not merge it.

This fix changes two things:
1. For Keras model, it will not pre-merge Activation nodes into Conv nodes. (Caffe model parsing does not pre-merge already)
2. When merging layers, it check if it can merge. BatchNorm layer will not merge if there is already an Activation layer merged.